### PR TITLE
Service の Type を ClusterIP にした

### DIFF
--- a/manifests/service.yml
+++ b/manifests/service.yml
@@ -9,4 +9,4 @@ spec:
     - protocol: TCP
       port: 80
       targetPort: 8080
-  type: LoadBalancer
+  type: ClusterIP


### PR DESCRIPTION
静的な IP を確保したくないため
基本的にポートフォワーディングを使う